### PR TITLE
Fix resume link

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -15,7 +15,7 @@
             <p class="p-first">I am a developer/programmer from india and have been writing code and problem solving since 2013.</p>
             <p class="p-second">I've previousy worked at <a
                     href="https://www.ltimindtree.com/">L&T Infotech</a>. you can
-                find my <a href="assets/Aunik_Resume.pdf" target="_blank">resume</a> here.</p>
+                find my <a href="https://github.com/aunikd/portfolio/blob/main/resume.pdf" target="_blank">resume</a> here.</p>
 
         </div>
     </div>


### PR DESCRIPTION
I have fixed resume link and it could be viewed on the new tab when user clicked on it. 

## Description
This pull request addresses an issue with the resume link in the application. The link has been updated to ensure that it opens in a new tab when clicked, providing a better user experience.

## Changes Made
- Updated the resume link to open in a new tab.

## How to Test
1. Navigate to the home page of the application. 
2. Click on the resume word.
3. Confirm that the resume opens in a new tab.